### PR TITLE
Build 'dev' container image on push to 'main' branch

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -2,7 +2,9 @@ name: Build and Push Docker Image
 
 on:
   push:
-    tags: 
+    branches:
+      - 'main'
+    tags:
       - 'v*'
 
 env:
@@ -40,7 +42,8 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=sha,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
+            type=raw,value=dev,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}


### PR DESCRIPTION
- fixes #59 
- the latest commit `main` triggers a workflow to built a container image with the tag `dev`
- additionally, every image gets the tagged with the short commit sha of its corresponding commit
- The change is difficult to test in production, but I tried it on my fork and it worked. We should observe if everything works as expected on this repository. 
